### PR TITLE
add composer.lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 ktest
 vendor/
+composer.lock


### PR DESCRIPTION
They're generated by tests; we don't want to keep these
artifacts in the repo itself