### PR TITLE
added output in Teamcity format for benchmarks

### DIFF
--- a/cmd/ktest/main.go
+++ b/cmd/ktest/main.go
@@ -143,6 +143,8 @@ func cmdBenchPHP(args []string) error {
 		`PHP command to run the benchmarks`)
 	fs.BoolVar(&conf.DisableAutoloadForKPHP, "disable-kphp-autoload", false,
 		`disables autoload for KPHP`)
+	fs.BoolVar(&conf.TeamcityOutput, "teamcity", false,
+		`report bench execution progress in TeamCity format`)
 	fs.Parse(args)
 
 	if len(fs.Args()) == 0 {
@@ -189,6 +191,8 @@ func cmdBench(args []string) error {
 		`comma separated list of additional kphp include-dirs`)
 	fs.BoolVar(&conf.DisableAutoloadForKPHP, "disable-kphp-autoload", false,
 		`disables autoload for KPHP`)
+	fs.BoolVar(&conf.TeamcityOutput, "teamcity", false,
+		`report bench execution progress in TeamCity format`)
 	fs.Parse(args)
 
 	if len(fs.Args()) == 0 {

--- a/internal/bench/bench.go
+++ b/internal/bench/bench.go
@@ -13,6 +13,7 @@ type RunConfig struct {
 
 	AdditionalKphpIncludeDirs string
 	DisableAutoloadForKPHP    bool
+	TeamcityOutput            bool
 
 	Count int
 

--- a/internal/teamcity/teamcity.go
+++ b/internal/teamcity/teamcity.go
@@ -1,0 +1,32 @@
+package teamcity
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+type Logger struct {
+	writer io.Writer
+}
+
+func NewLogger(writer io.Writer) *Logger {
+	return &Logger{writer: writer}
+}
+
+func (l *Logger) TestSuiteStarted(name string) {
+	fmt.Fprintf(l.writer, "##teamcity[testSuiteStarted name='%s']\n", strings.TrimPrefix(name, "Benchmark"))
+}
+
+func (l *Logger) TestSuiteFinished(name string, duration time.Duration) {
+	fmt.Fprintf(l.writer, "##teamcity[testSuiteFinished name='%s' duration='%s']\n", strings.TrimPrefix(name, "Benchmark"), duration.String())
+}
+
+func (l *Logger) TestStarted(name string) {
+	fmt.Fprintf(l.writer, "##teamcity[testStarted name='%s']\n", strings.TrimPrefix(name, "Benchmark"))
+}
+
+func (l *Logger) TestFinished(name string) {
+	fmt.Fprintf(l.writer, "##teamcity[testFinished name='%s']\n", strings.TrimPrefix(name, "Benchmark"))
+}


### PR DESCRIPTION
This is necessary so that when we run the `ktest` through PhpStorm,
it can parse the names and locations of the benchmarks correctly,
as well as know when the benchmark started and ended.