### PR TITLE
fixed benchmark methods name in teamcity output

### DIFF
--- a/internal/bench/ast_visitor.go
+++ b/internal/bench/ast_visitor.go
@@ -63,6 +63,6 @@ func (v *astVisitor) StmtClassMethod(n *ast.StmtClassMethod) {
 	}
 	v.out.BenchMethods = append(v.out.BenchMethods, benchMethod{
 		Name: methodName,
-		Key:  strings.TrimPrefix(methodName, "benchmark"),
+		Key:  strings.TrimPrefix(strings.TrimPrefix(methodName, "benchmark"), "_"),
 	})
 }

--- a/internal/bench/runner.go
+++ b/internal/bench/runner.go
@@ -267,15 +267,19 @@ function remove_prefix($text, $prefix) {
   return $text;
 }
 
+function remove_benchmark_prefix($text) {
+  return remove_prefix(remove_prefix($text, "benchmark"), "_");
+}
+
 function test_started(string $name, string $place) {
 {{if .Teamcity}}
-  fprintf(STDERR, "##teamcity[testStarted name='%s' locationHint='{{.BenchQN}}%s']\n", remove_prefix($name, "benchmark"), $place);
+  fprintf(STDERR, "##teamcity[testStarted name='%s' locationHint='{{.BenchQN}}%s']\n", remove_benchmark_prefix($name), $place);
 {{end}}
 }
 
 function test_finished(string $name) {
 {{if .Teamcity}}
-  fprintf(STDERR, "##teamcity[testFinished name='%s']\n", remove_prefix($name, "benchmark"));
+  fprintf(STDERR, "##teamcity[testFinished name='%s']\n", remove_benchmark_prefix($name));
 {{end}}
 }
 


### PR DESCRIPTION
If the benchmark method starts with `benchmark_`, then delete `_` too.

Fixed #11 