### PR TITLE
added check that the file name matches the class name of the benchmark inside

### DIFF
--- a/internal/bench/runner.go
+++ b/internal/bench/runner.go
@@ -181,8 +181,12 @@ func (r *runner) stepParseBenchFiles() error {
 			return err
 		}
 		f.info = &benchParsedInfo{}
-		visitor := &astVisitor{out: f.info}
+		visitor := &astVisitor{out: f.info, currentFileName: f.shortName}
 		traverser.NewTraverser(visitor).Traverse(rootNode)
+
+		for _, err = range visitor.issues {
+			return err
+		}
 
 		if f.info.ClassFQN == "" {
 			return fmt.Errorf("%s: can't find a benchmark class inside a file", f.shortName)


### PR DESCRIPTION
Otherwise, KPHP will not be able to find the class.

Fixed #9 