### PR TITLE
internal/bench: add benchmem flag support

### DIFF
--- a/cmd/ktest/main.go
+++ b/cmd/ktest/main.go
@@ -207,6 +207,8 @@ func cmdBench(args []string) error {
 		`disables autoload for KPHP`)
 	fs.BoolVar(&conf.TeamcityOutput, "teamcity", false,
 		`report bench execution progress in TeamCity format`)
+	fs.BoolVar(&conf.Benchmem, "benchmem", false,
+		`print memory allocation statistics for benchmarks`)
 	fs.Parse(args)
 
 	if len(fs.Args()) == 0 {

--- a/internal/bench/bench.go
+++ b/internal/bench/bench.go
@@ -16,6 +16,7 @@ type RunConfig struct {
 	AdditionalKphpIncludeDirs string
 	DisableAutoloadForKPHP    bool
 	TeamcityOutput            bool
+	Benchmem                  bool
 
 	Count int
 


### PR DESCRIPTION
`ktest bench -benchmem` enables allocations tracking.
In addition to CPU time, allocations stats will be reported
for every benchmark.

	BenchmarkArray::Literal	460840	63.0 ns/op	72 B/op	1 allocs/op

B/op - number of bytes allocated per operation.
allocs/op - number of memory allocations per operation.

Note that both stats are calculated "on average". So if your
benchmark allocates only sometimes, it will affect the stats.
This is done on purpose.

They can be compared with benchstat later.

	name            old time/op    new time/op    delta
	Array::Literal    63.2ns ± 2%    14.0ns ± 0%   -77.85%  (p=0.008 n=5+5)
	name            old alloc/op   new alloc/op   delta
	Array::Literal     72.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
	name            old allocs/op  new allocs/op  delta
	Array::Literal      1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)