### PR TITLE
cmd/ktest: add bench-ab command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 * `ktest phpunit` can run [PHPUnit](https://github.com/sebastianbergmann/phpunit) tests using KPHP
 * `ktest compare` run given script with PHP and KPHP, check that output is identical (useful for runnable examples)
 * `ktest bench` run benchmarks using KPHP
+* `ktest bench-ab` run two selected benchmarks using KPHP and compare their results
 * `ktest bench-php` run benchmarks using PHP
 * `ktest bench-vs-php` run benchmarks using both KPHP and PHP, compare the results
 * `ktest benchstat` compute and compare statistics about benchmark results (see [benchstat](https://godoc.org/golang.org/x/perf/cmd/benchstat))

--- a/cmd/ktest/ab.go
+++ b/cmd/ktest/ab.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+
+	"golang.org/x/perf/benchstat"
+)
+
+func cmdBenchAB(args []string) error {
+	fs := flag.NewFlagSet("ktest bench-ab", flag.ExitOnError)
+	fs.Usage = func() {
+		log.Printf("Usage: ktest bench-ab Old New [...bench command args]")
+		log.Printf("Old is a regexp for A benchmark name")
+		log.Printf("New is a regexp for B benchmark name")
+		log.Printf("To see bench args run `ktest bench --help`")
+	}
+	fs.Parse(args)
+
+	if len(fs.Args()) < 2 {
+		fs.Usage()
+		return errors.New("not enough arguments")
+	}
+
+	oldPattern := fs.Arg(0)
+	newPattern := fs.Arg(1)
+
+	oldRegexp, err := regexp.Compile(oldPattern)
+	if err != nil {
+		return fmt.Errorf("compile Old (A) benchmark pattern %q: %v", oldPattern, err)
+	}
+	newRegexp, err := regexp.Compile(newPattern)
+	if err != nil {
+		return fmt.Errorf("compile New (B) benchmark pattern %q: %v", newPattern, err)
+	}
+
+	// In case error occurs, we want to clear all progress-related text.
+	defer func() {
+		flushProgress()
+	}()
+
+	printProgress("compiling KPHP benchmarks...")
+	benchArgs := []string{"bench"}
+	benchArgs = append(benchArgs, fs.Args()[2:]...)
+	out, err := runBenchWithProgress(oldPattern+" and "+newPattern, os.Args[0], benchArgs)
+	if err != nil {
+		return err
+	}
+
+	// Divide collected samples in three groups:
+	// 1. old result set
+	// 2. new result set
+	// 3. ignored result set (not actually saved)
+	var oldResults bytes.Buffer
+	var newResults bytes.Buffer
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "Benchmark") {
+			continue
+		}
+		tabPos := strings.IndexByte(line, '\t')
+		if tabPos == -1 {
+			continue
+		}
+		benchName := line[:tabPos]
+		// We'll get "Benchmark" title in the output since one Benchmark
+		// prefix will be removed by the benchstat.
+		newLine := "BenchmarkBenchmark" + line[tabPos:]
+		if oldRegexp.MatchString(benchName) {
+			oldResults.WriteString(newLine + "\n")
+		} else if newRegexp.MatchString(benchName) {
+			newResults.WriteString(newLine + "\n")
+		}
+	}
+
+	// Run a benchstat without running subcommand and creating extra tmp files.
+	// We'll use the default options and colored output.
+	benchstatCollection := &benchstat.Collection{
+		Alpha:     0.05,
+		DeltaTest: benchstat.UTest,
+	}
+	if err := benchstatCollection.AddFile("old", &oldResults); err != nil {
+		return err
+	}
+	if err := benchstatCollection.AddFile("new", &newResults); err != nil {
+		return err
+	}
+	tables := benchstatCollection.Tables()
+	colorizeBenchstatTables(tables)
+
+	flushProgress()
+	var buf bytes.Buffer
+	benchstat.FormatText(&buf, tables)
+	os.Stdout.Write(buf.Bytes())
+
+	return nil
+}

--- a/cmd/ktest/benchstat.go
+++ b/cmd/ktest/benchstat.go
@@ -12,23 +12,34 @@ import (
 	"golang.org/x/perf/benchstat"
 )
 
-func colorizeText(str string, colorCode string, enableColorize bool) string {
-	if enableColorize {
-		return strings.Join([]string{colorCode, str, "\033[0m"}, "")
+func colorizeText(str string, colorCode string) string {
+	return colorCode + str + "\033[0m"
+}
+
+func redColorize(str string) string {
+	return colorizeText(str, "\033[31m")
+}
+
+func greenColorize(str string) string {
+	return colorizeText(str, "\033[32m")
+}
+
+func yellowColorize(str string) string {
+	return colorizeText(str, "\033[33m")
+}
+
+func colorizeBenchstatTables(tables []*benchstat.Table) {
+	for _, table := range tables {
+		for _, row := range table.Rows {
+			if strings.HasPrefix(row.Delta, "+") {
+				row.Delta = redColorize(row.Delta)
+			} else if strings.HasPrefix(row.Delta, "-") {
+				row.Delta = greenColorize(row.Delta)
+			} else {
+				row.Delta = yellowColorize(row.Delta)
+			}
+		}
 	}
-	return str
-}
-
-func redColorize(str string, enableColorize bool) string {
-	return colorizeText(str, "\033[31m", enableColorize)
-}
-
-func greenColorize(str string, enableColorize bool) string {
-	return colorizeText(str, "\033[32m", enableColorize)
-}
-
-func yellowColorize(str string, enableColorize bool) string {
-	return colorizeText(str, "\033[33m", enableColorize)
 }
 
 func cmdBenchstat(args []string) error {
@@ -109,16 +120,8 @@ func cmdBenchstat(args []string) error {
 	}
 
 	tables := c.Tables()
-	for _, table := range tables {
-		for _, row := range table.Rows {
-			if strings.HasPrefix(row.Delta, "+") {
-				row.Delta = redColorize(row.Delta, enableColorize)
-			} else if strings.HasPrefix(row.Delta, "-") {
-				row.Delta = greenColorize(row.Delta, enableColorize)
-			} else {
-				row.Delta = yellowColorize(row.Delta, enableColorize)
-			}
-		}
+	if enableColorize {
+		colorizeBenchstatTables(tables)
 	}
 	var buf bytes.Buffer
 	benchstat.FormatText(&buf, tables)

--- a/cmd/ktest/main.go
+++ b/cmd/ktest/main.go
@@ -57,6 +57,12 @@ func main() {
 		},
 
 		{
+			Name:        "bench-ab",
+			Description: "run two selected benchmarks using KPHP and compare their results",
+			Do:          benchABMain,
+		},
+
+		{
 			Name:        "bench-php",
 			Description: "run benchmarks using PHP",
 			Do:          benchPHPMain,
@@ -114,6 +120,12 @@ func benchstatMain(args []string) {
 func benchMain(args []string) {
 	if err := cmdBench(args); err != nil {
 		log.Fatalf("ktest bench: error: %v", err)
+	}
+}
+
+func benchABMain(args []string) {
+	if err := cmdBenchAB(args); err != nil {
+		log.Fatalf("ktest bench-ab: error: %v", err)
 	}
 }
 

--- a/cmd/ktest/utils.go
+++ b/cmd/ktest/utils.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+)
+
+func printProgress(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	fmt.Fprintf(os.Stderr, "\033[2K\r%s", msg)
+}
+
+func flushProgress() {
+	printProgress("")
+}
+
+func runBenchWithProgress(label, command string, args []string) ([]byte, error) {
+	cmd := exec.Command(command, args...)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	completed := 0
+	ch := make(chan error)
+	ticker := time.NewTicker(1 * time.Second)
+	go func() {
+		ch <- cmd.Run()
+	}()
+	for {
+		select {
+		case err := <-ch:
+			if err != nil {
+				combined := append(stderr.Bytes(), stdout.Bytes()...)
+				return nil, fmt.Errorf("run %s benchmarks: %v: %s", label, err, combined)
+			}
+			return stdout.Bytes(), nil
+		case <-ticker.C:
+			lines := bytes.Count(stdout.Bytes(), []byte("\n"))
+			if completed != lines {
+				completed = lines
+				printProgress("running %s benchmarks: got %d samples...", label, completed)
+			}
+		}
+	}
+}


### PR DESCRIPTION
bench-ab is a helper command that runs two benchmark
sets and compares them.