### PR TITLE
internal/bench: fixed ab args

### DIFF
--- a/cmd/ktest/ab.go
+++ b/cmd/ktest/ab.go
@@ -176,7 +176,27 @@ func runFuncsAB(oldPattern, newPattern string, args []string) (*abResult, error)
 }
 
 func runFilesAB(oldFilename, newFilename string, args []string) (*abResult, error) {
-	benchArgs := []string{"bench", "--count", "10", "--benchmem"}
+	withBenchmem := false
+	withCount := false
+	for _, arg := range args {
+		flagName := strings.TrimLeft(arg, "-")
+		if flagName == "benchmem" {
+			withBenchmem = true
+		}
+		if flagName == "count" {
+			withCount = true
+		}
+	}
+
+	benchArgs := append([]string{"bench"}, args...)
+
+	if !withBenchmem {
+		benchArgs = append(benchArgs, "--benchmem")
+	}
+
+	if !withCount {
+		benchArgs = append(benchArgs, "--count", "10")
+	}
 
 	oldKey := strings.TrimSuffix(filepath.Base(oldFilename), ".php")
 	newKey := strings.TrimSuffix(filepath.Base(newFilename), ".php")


### PR DESCRIPTION
Now if you try to run the command with some arguments:

```
./ktest bench-ab file1.php file2.php --kphp2cpp-binary ./bin/kphp2cpp
```

Then the `--kphp2cpp-binary` flag (and other if exists) will not be used to run the benchmark, resulting in errors.

This PR fixes this behavior by leaving the default flag logic if none were provided.